### PR TITLE
Webpack the right way. #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 .module-cache
 build/
+public/bundle.js
 
 # Ignoring editor specific files
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server --open --hot --mode development",
+    "start": "webpack-dev-server --open --hot --mode development --content-base public",
     "build": "webpack --mode production"
   },
   "repository": {

--- a/public/index.html
+++ b/public/index.html
@@ -12,5 +12,6 @@
     </head>
     <body>
         <section id="root"></section>
+	<script src="bundle.js"></script>
     </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 const App = () => {
-  return <div>Hello World!</div>;
+  return <div>Hello Poeperd!</div>;
 };
 
 ReactDOM.render(<App />, document.querySelector("#root"));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,10 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 module.exports = {
+  entry: './src/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: __dirname + '/public'
+  },
   module: {
     rules: [
       {
@@ -8,21 +13,7 @@ module.exports = {
         use: {
           loader: "babel-loader"
         }
-      },
-      {
-        test: /\.html$/,
-        use: [
-          {
-            loader: "html-loader"
-          }
-        ]
       }
     ]
-  },
-  plugins: [
-    new HtmlWebPackPlugin({
-      template: "./src/index.html",
-      filename: "./index.html"
-    })
-  ]
+  }
 };


### PR DESCRIPTION
We realized that the HTML loader wasn't needed, so we removed it. Also, the content base of the development server is set to `public`, as we want to separate the src (javascript) from public files such as html and css.